### PR TITLE
Update application links with Recruitee mailbox and URLs

### DIFF
--- a/join-us/openings/lead-android-developer.md
+++ b/join-us/openings/lead-android-developer.md
@@ -57,8 +57,6 @@ we work on.
 
 There are two ways to send us your application:
 
-* Send us an email to work@nimblehq.co with your resume or LinkedIn profile along with any other details that would help 
+* Send us an email to **job.ee3oa@nimble.recruitee.com** or **work@nimblehq.co** with your resume or LinkedIn profile along with any other details that would help 
 in assessing your application better e.g. Github account, Stack Overflow account, side projects.
-* Fill in the application form on [our recruitment platform Workhiro](https://www.workhiro.com/companies/nimble/8459614e/apply?locale=en)
-
-
+* Fill in the application form on [our jobs site](https://jobs.nimblehq.co/o/lead-android-developer)

--- a/join-us/openings/lead-web-developer.md
+++ b/join-us/openings/lead-web-developer.md
@@ -57,6 +57,6 @@ we work on.
 
 There are two ways to send us your application:
 
-* Send us an email to work@nimblehq.co with your resume or LinkedIn profile along with any other details that would help 
+* Send us an email to **job.39ahc@nimble.recruitee.com** or **work@nimblehq.co** with your resume or LinkedIn profile along with any other details that would help 
 in assessing your application better e.g. Github account, Stack Overflow account, side projects.
-* Fill in the application form on [our recruitment platform Workhiro](https://www.workhiro.com/companies/nimble/faef810e?locale=en)
+* Fill in the application form on [our jobs site](https://jobs.nimblehq.co/o/lead-web-developer)

--- a/join-us/openings/ruby-rails-developer.md
+++ b/join-us/openings/ruby-rails-developer.md
@@ -56,6 +56,6 @@ we work on.
 
 There are two ways to send us your application:
 
-* Send us an email to work@nimblehq.co with your resume or LinkedIn profile along with any other details that would help 
+* Send us an email to **job.2nv56@nimble.recruitee.com** or **work@nimblehq.co** with your resume or LinkedIn profile along with any other details that would help 
 in assessing your application better e.g. Github account, Stack Overflow account, side projects.
-* Fill in the application form on [our recruitment platform Workhiro](https://www.workhiro.com/companies/nimble/049ee05b/apply?locale=en)
+* Fill in the application form on [our jobs site](https://jobs.nimblehq.co/o/rubyrails-developer-bangkok)

--- a/join-us/openings/technical-product-owner.md
+++ b/join-us/openings/technical-product-owner.md
@@ -57,7 +57,6 @@ we work on.
 
 ## How to apply
 
-There are two ways to send us your application:
-* Send us an email to work@nimblehq.co with your resume or LinkedIn profile along with any other details that would help 
+* Send us an email to **job.atl18@nimble.recruitee.com** or **work@nimblehq.co** with your resume or LinkedIn profile along with any other details that would help 
 in assessing your application better e.g. Github account, Stack Overflow account, side projects.
-* Fill in the application form on [our recruitment platform Workhiro](https://www.workhiro.com/companies/nimble/2eef1fa0/apply?locale=en)
+* Fill in the application form on [our jobs site](https://jobs.nimblehq.co/o/technical-product-owner)


### PR DESCRIPTION
## What happened

As you migrated from Workhiro to Recruitee for our ATS, this PR updates all application links with Recruitee ones. 
 
## Insight

I used the custom mailbox addresses instead of the generic `work@nimblehq.co`. It's easier for us to manage but I still left the option to use `work@nimblehq.co`.