### PR TITLE
Update vacancies URLs

### DIFF
--- a/join-us/openings/internship-software-developer.md
+++ b/join-us/openings/internship-software-developer.md
@@ -69,6 +69,6 @@ Read what some of past interns had to say about their internship with us:
 
 There are two ways to send us your application:
 
-* Send us an email to **job.bp9pk@nimble.recruitee.com** or **work@nimblehq.co** with your resume or LinkedIn profile along with any other details that would help 
+* Send us an email to **work@nimblehq.co** with your resume or LinkedIn profile along with any other details that would help 
 in assessing your application better e.g. Github account, Stack Overflow account, side projects.
 * Fill in the application form on [our jobs site](https://jobs.nimblehq.co/o/internship-software-developer)

--- a/join-us/openings/internship-software-developer.md
+++ b/join-us/openings/internship-software-developer.md
@@ -69,6 +69,6 @@ Read what some of past interns had to say about their internship with us:
 
 There are two ways to send us your application:
 
-* Send us an email to **work@nimblehq.co** with your resume or LinkedIn profile along with any other details that would help 
+* Send us an email to **work@nimble.recruitee.com** with your resume or LinkedIn profile along with any other details that would help 
 in assessing your application better e.g. Github account, Stack Overflow account, side projects.
 * Fill in the application form on [our jobs site](https://jobs.nimblehq.co/o/internship-software-developer)

--- a/join-us/openings/lead-android-developer.md
+++ b/join-us/openings/lead-android-developer.md
@@ -64,6 +64,6 @@ Want to see what we have built? Check our selected [portfolio](https://nimblehq.
 
 There are two ways to send us your application:
 
-* Send us an email to **job.ee3oa@nimble.recruitee.com** or **work@nimblehq.co** with your resume or LinkedIn profile along with any other details that would help 
+* Send us an email to **work@nimblehq.co** with your resume or LinkedIn profile along with any other details that would help 
 in assessing your application better e.g. Github account, Stack Overflow account, side projects.
 * Fill in the application form on [our jobs site](https://jobs.nimblehq.co/o/lead-android-developer)

--- a/join-us/openings/lead-android-developer.md
+++ b/join-us/openings/lead-android-developer.md
@@ -64,6 +64,6 @@ Want to see what we have built? Check our selected [portfolio](https://nimblehq.
 
 There are two ways to send us your application:
 
-* Send us an email to **work@nimblehq.co** with your resume or LinkedIn profile along with any other details that would help 
+* Send us an email to **work@nimble.recruitee.com** with your resume or LinkedIn profile along with any other details that would help 
 in assessing your application better e.g. Github account, Stack Overflow account, side projects.
 * Fill in the application form on [our jobs site](https://jobs.nimblehq.co/o/lead-android-developer-bangkok)

--- a/join-us/openings/lead-android-developer.md
+++ b/join-us/openings/lead-android-developer.md
@@ -66,4 +66,4 @@ There are two ways to send us your application:
 
 * Send us an email to **work@nimblehq.co** with your resume or LinkedIn profile along with any other details that would help 
 in assessing your application better e.g. Github account, Stack Overflow account, side projects.
-* Fill in the application form on [our jobs site](https://jobs.nimblehq.co/o/lead-android-developer)
+* Fill in the application form on [our jobs site](https://jobs.nimblehq.co/o/lead-android-developer-bangkok)

--- a/join-us/openings/lead-ios-developer.md
+++ b/join-us/openings/lead-ios-developer.md
@@ -64,6 +64,6 @@ Want to see what we have built? Check our selected [portfolio](https://nimblehq.
 
 There are two ways to send us your application:
 
-* Send us an email to **job.ah5fp@nimble.recruitee.com** or **work@nimblehq.co** with your resume or LinkedIn profile along with any other details that would help 
+* Send us an email to **work@nimblehq.co** with your resume or LinkedIn profile along with any other details that would help 
 in assessing your application better e.g. Github account, Stack Overflow account, side projects.
 * Fill in the application form on [our jobs site](http://jobs.nimblehq.co/o/lead-ios-developer)

--- a/join-us/openings/lead-ios-developer.md
+++ b/join-us/openings/lead-ios-developer.md
@@ -66,4 +66,4 @@ There are two ways to send us your application:
 
 * Send us an email to **work@nimblehq.co** with your resume or LinkedIn profile along with any other details that would help 
 in assessing your application better e.g. Github account, Stack Overflow account, side projects.
-* Fill in the application form on [our jobs site](http://jobs.nimblehq.co/o/lead-ios-developer)
+* Fill in the application form on [our jobs site](https://jobs.nimblehq.co/o/lead-ios-developer-bangkok)

--- a/join-us/openings/lead-ios-developer.md
+++ b/join-us/openings/lead-ios-developer.md
@@ -64,6 +64,6 @@ Want to see what we have built? Check our selected [portfolio](https://nimblehq.
 
 There are two ways to send us your application:
 
-* Send us an email to **work@nimblehq.co** with your resume or LinkedIn profile along with any other details that would help 
+* Send us an email to **work@nimble.recruitee.com** with your resume or LinkedIn profile along with any other details that would help 
 in assessing your application better e.g. Github account, Stack Overflow account, side projects.
 * Fill in the application form on [our jobs site](https://jobs.nimblehq.co/o/lead-ios-developer-bangkok)

--- a/join-us/openings/lead-web-developer.md
+++ b/join-us/openings/lead-web-developer.md
@@ -67,4 +67,4 @@ There are two ways to send us your application:
 
 * Send us an email to **work@nimblehq.co** with your resume or LinkedIn profile along with any other details that would help 
 in assessing your application better e.g. Github account, Stack Overflow account, side projects.
-* Fill in the application form on [our jobs site](https://jobs.nimblehq.co/o/lead-web-developer)
+* Fill in the application form on [our jobs site](https://jobs.nimblehq.co/o/lead-web-developer-bangkok)

--- a/join-us/openings/lead-web-developer.md
+++ b/join-us/openings/lead-web-developer.md
@@ -65,6 +65,6 @@ Want to see what we have built? Check our selected [portfolio](https://nimblehq.
 
 There are two ways to send us your application:
 
-* Send us an email to **work@nimblehq.co** with your resume or LinkedIn profile along with any other details that would help 
+* Send us an email to **work@nimble.recruitee.com** with your resume or LinkedIn profile along with any other details that would help 
 in assessing your application better e.g. Github account, Stack Overflow account, side projects.
 * Fill in the application form on [our jobs site](https://jobs.nimblehq.co/o/lead-web-developer-bangkok)

--- a/join-us/openings/lead-web-developer.md
+++ b/join-us/openings/lead-web-developer.md
@@ -65,6 +65,6 @@ Want to see what we have built? Check our selected [portfolio](https://nimblehq.
 
 There are two ways to send us your application:
 
-* Send us an email to **job.39ahc@nimble.recruitee.com** or **work@nimblehq.co** with your resume or LinkedIn profile along with any other details that would help 
+* Send us an email to **work@nimblehq.co** with your resume or LinkedIn profile along with any other details that would help 
 in assessing your application better e.g. Github account, Stack Overflow account, side projects.
 * Fill in the application form on [our jobs site](https://jobs.nimblehq.co/o/lead-web-developer)

--- a/join-us/openings/ruby-rails-developer-bangkok.md
+++ b/join-us/openings/ruby-rails-developer-bangkok.md
@@ -66,4 +66,4 @@ There are two ways to send us your application:
 
 * Send us an email to **work@nimblehq.co** with your resume or LinkedIn profile along with any other details that would help 
 in assessing your application better e.g. Github account, Stack Overflow account, side projects.
-* Fill in the application form on [our jobs site](https://jobs.nimblehq.co/o/rubyrails-developer-bangkok)
+* Fill in the application form on [our jobs site](https://jobs.nimblehq.co/o/rubyrails-developer-1)

--- a/join-us/openings/ruby-rails-developer-bangkok.md
+++ b/join-us/openings/ruby-rails-developer-bangkok.md
@@ -64,6 +64,6 @@ Want to see what we have built? Check our selected [portfolio](https://nimblehq.
 
 There are two ways to send us your application:
 
-* Send us an email to **job.2nv56@nimble.recruitee.com** or **work@nimblehq.co** with your resume or LinkedIn profile along with any other details that would help 
+* Send us an email to **work@nimblehq.co** with your resume or LinkedIn profile along with any other details that would help 
 in assessing your application better e.g. Github account, Stack Overflow account, side projects.
 * Fill in the application form on [our jobs site](https://jobs.nimblehq.co/o/rubyrails-developer-bangkok)

--- a/join-us/openings/ruby-rails-developer-bangkok.md
+++ b/join-us/openings/ruby-rails-developer-bangkok.md
@@ -64,6 +64,6 @@ Want to see what we have built? Check our selected [portfolio](https://nimblehq.
 
 There are two ways to send us your application:
 
-* Send us an email to **work@nimblehq.co** with your resume or LinkedIn profile along with any other details that would help 
+* Send us an email to **work@nimble.recruitee.com** with your resume or LinkedIn profile along with any other details that would help 
 in assessing your application better e.g. Github account, Stack Overflow account, side projects.
 * Fill in the application form on [our jobs site](https://jobs.nimblehq.co/o/rubyrails-developer-1)

--- a/join-us/openings/ruby-rails-developer-danang.md
+++ b/join-us/openings/ruby-rails-developer-danang.md
@@ -62,6 +62,6 @@ Want to see what we have built? Check our selected [portfolio](https://nimblehq.
 
 There are two ways to send us your application:
 
-* Send us an email to **job.a3mth@nimble.recruitee.com** or **work@nimblehq.co** with your resume or LinkedIn profile along with any other details that would help 
+* Send us an email to **work@nimblehq.co** with your resume or LinkedIn profile along with any other details that would help 
 in assessing your application better e.g. Github account, Stack Overflow account, side projects.
 * Fill in the application form on [our jobs site](https://jobs.nimblehq.co/o/rubyrails-developer)

--- a/join-us/openings/ruby-rails-developer-danang.md
+++ b/join-us/openings/ruby-rails-developer-danang.md
@@ -62,6 +62,6 @@ Want to see what we have built? Check our selected [portfolio](https://nimblehq.
 
 There are two ways to send us your application:
 
-* Send us an email to **work@nimblehq.co** with your resume or LinkedIn profile along with any other details that would help 
+* Send us an email to **work@nimble.recruitee.com** with your resume or LinkedIn profile along with any other details that would help 
 in assessing your application better e.g. Github account, Stack Overflow account, side projects.
 * Fill in the application form on [our jobs site](https://jobs.nimblehq.co/o/rubyrails-developer-2)

--- a/join-us/openings/ruby-rails-developer-danang.md
+++ b/join-us/openings/ruby-rails-developer-danang.md
@@ -64,4 +64,4 @@ There are two ways to send us your application:
 
 * Send us an email to **work@nimblehq.co** with your resume or LinkedIn profile along with any other details that would help 
 in assessing your application better e.g. Github account, Stack Overflow account, side projects.
-* Fill in the application form on [our jobs site](https://jobs.nimblehq.co/o/rubyrails-developer)
+* Fill in the application form on [our jobs site](https://jobs.nimblehq.co/o/rubyrails-developer-2)

--- a/join-us/openings/technical-product-owner.md
+++ b/join-us/openings/technical-product-owner.md
@@ -62,6 +62,6 @@ Want to see what we have built? Check our selected [portfolio](https://nimblehq.
 
 ## How to apply
 
-* Send us an email to **job.atl18@nimble.recruitee.com** or **work@nimblehq.co** with your resume or LinkedIn profile along with any other details that would help 
+* Send us an email to **work@nimblehq.co** with your resume or LinkedIn profile along with any other details that would help 
 in assessing your application better e.g. Github account, Stack Overflow account, side projects.
 * Fill in the application form on [our jobs site](https://jobs.nimblehq.co/o/technical-product-owner)

--- a/join-us/openings/technical-product-owner.md
+++ b/join-us/openings/technical-product-owner.md
@@ -62,6 +62,6 @@ Want to see what we have built? Check our selected [portfolio](https://nimblehq.
 
 ## How to apply
 
-* Send us an email to **work@nimblehq.co** with your resume or LinkedIn profile along with any other details that would help 
+* Send us an email to **work@nimble.recruitee.com** with your resume or LinkedIn profile along with any other details that would help 
 in assessing your application better e.g. Github account, Stack Overflow account, side projects.
 * Fill in the application form on [our jobs site](https://jobs.nimblehq.co/o/technical-product-owner-bangkok)

--- a/join-us/openings/technical-product-owner.md
+++ b/join-us/openings/technical-product-owner.md
@@ -64,4 +64,4 @@ Want to see what we have built? Check our selected [portfolio](https://nimblehq.
 
 * Send us an email to **work@nimblehq.co** with your resume or LinkedIn profile along with any other details that would help 
 in assessing your application better e.g. Github account, Stack Overflow account, side projects.
-* Fill in the application form on [our jobs site](https://jobs.nimblehq.co/o/technical-product-owner)
+* Fill in the application form on [our jobs site](https://jobs.nimblehq.co/o/technical-product-owner-bangkok)

--- a/join-us/openings/web-developer.md
+++ b/join-us/openings/web-developer.md
@@ -63,6 +63,6 @@ Want to see what we have built? Check our selected [portfolio](https://nimblehq.
 
 There are two ways to send us your application:
 
-* Send us an email to **work@nimblehq.co** with your resume or LinkedIn profile along with any other details that would help 
+* Send us an email to **work@nimble.recruitee.com** with your resume or LinkedIn profile along with any other details that would help 
 in assessing your application better e.g. Github account, Stack Overflow account, side projects.
 * Fill in the application form on [our jobs site](https://jobs.nimblehq.co/o/web-developer-bangkok)

--- a/join-us/openings/web-developer.md
+++ b/join-us/openings/web-developer.md
@@ -63,6 +63,6 @@ Want to see what we have built? Check our selected [portfolio](https://nimblehq.
 
 There are two ways to send us your application:
 
-* Send us an email to **job.mwrkm@nimble.recruitee.com** or **work@nimblehq.co** with your resume or LinkedIn profile along with any other details that would help 
+* Send us an email to **work@nimblehq.co** with your resume or LinkedIn profile along with any other details that would help 
 in assessing your application better e.g. Github account, Stack Overflow account, side projects.
 * Fill in the application form on [our jobs site](http://jobs.nimblehq.co/o/web-developer)

--- a/join-us/openings/web-developer.md
+++ b/join-us/openings/web-developer.md
@@ -65,4 +65,4 @@ There are two ways to send us your application:
 
 * Send us an email to **work@nimblehq.co** with your resume or LinkedIn profile along with any other details that would help 
 in assessing your application better e.g. Github account, Stack Overflow account, side projects.
-* Fill in the application form on [our jobs site](http://jobs.nimblehq.co/o/web-developer)
+* Fill in the application form on [our jobs site](https://jobs.nimblehq.co/o/web-developer-bangkok)

--- a/join-us/our-recruitment-process.md
+++ b/join-us/our-recruitment-process.md
@@ -145,7 +145,7 @@ so applicants who have not been selected should not be discouraged from seeking 
 
 ## Openings
 
-We are always on the look-out for great people to join us so don't hesitate to send us your application to work@nimblehq.co. 
+We are always on the look-out for great people to join us so don't hesitate to send us your application to work@nimble.recruitee.com. 
 
 We are currently hiring for the following positions:
 


### PR DESCRIPTION
## What happened

- Remove job-specific Recruitee inbox email for applications as these are not fixed and gets updated often when reposting job. Instead, use the global `work@nimble.recruitee.com` for all jobs.
- Use current URLs for all job positions

## Insight

Using all URLs from https://jobs.nimblehq.co/

## Proof Of Work

`N/A`